### PR TITLE
fix: 🐛 anim flag didn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v0.1.0-beta – Initial Beta Release
+## [v0.1.1-beta](https://github.com/nickwelsh/fennel/releases/tag/v0.1.1-beta) - 2025-04-16
+### Fixed
+- `anim` flag was previously ignored when rendering image URLs. It now correctly applies the animation parameter.
+
+## [v0.1.0-beta](https://github.com/nickwelsh/fennel/releases/tag/v0.1.0-beta) – Initial Beta Release
 
 This is the first beta release of **Fennel**,
 a self-hostable image optimization layer that closely mirrors Cloudflare's Image Resizing API.

--- a/src/Http/Controllers/ImageController.php
+++ b/src/Http/Controllers/ImageController.php
@@ -114,12 +114,12 @@ class ImageController extends Controller
             $path = public_path("images/$path");
             abort_unless(File::exists($path), 404);
 
-            return new ImageManager(Driver::class)->read($path);
+            return (new ImageManager(Driver::class))->read($path);
         }
 
         abort_unless(Storage::disk(Config::string('fennel.disk'))->exists($path), 404);
 
-        return new ImageManager(Driver::class)->read(Storage::disk(Config::string('fennel.disk'))->get($path));
+        return (new ImageManager(Driver::class))->read(Storage::disk(Config::string('fennel.disk'))->get($path));
     }
 
     // endregion
@@ -138,7 +138,8 @@ class ImageController extends Controller
     private function config(FennelImageService $image, array $options): FennelImageService
     {
         if (Arr::has($options, 'anim')) {
-            $shouldAnim = (bool) Arr::get($options, 'anim', Config::boolean('fennel.preserve_animation_frames'));
+            $animProp = Arr::get($options, 'anim', Config::boolean('fennel.preserve_animation_frames'));
+            $shouldAnim = ! in_array($animProp, ['no', 'off', '0', 0, false, 'false', null], true);
             $image->animate($shouldAnim);
         }
 

--- a/src/Services/FennelImageService.php
+++ b/src/Services/FennelImageService.php
@@ -95,7 +95,7 @@ class FennelImageService
     {
         $this->addQueryString('anim', $shouldAnimate);
 
-        if ($this->image->isAnimated() && ! $shouldAnimate) {
+        if ($this->image->isAnimated() && $shouldAnimate === false) {
             $this->image->removeAnimation();
         }
 


### PR DESCRIPTION
## [v0.1.1-beta](https://github.com/nickwelsh/fennel/releases/tag/v0.1.1-beta) - 2025-04-16
### Fixed
- `anim` flag was previously ignored when rendering image URLs. It now correctly applies the animation parameter.